### PR TITLE
Update paypal-models.ts

### DIFF
--- a/projects/ngx-paypal-lib/src/lib/models/paypal-models.ts
+++ b/projects/ngx-paypal-lib/src/lib/models/paypal-models.ts
@@ -95,6 +95,7 @@ export interface IOrderDetails {
     payer: IPayer;
     status: OrderStatus;
     links: ILinkDescription[];
+    purchase_units: IPurchaseUnit[];
 }
 
 export interface ILinkDescription {


### PR DESCRIPTION
As per suggested fix for:
Property 'purchase_units' does not exist on type 'IClientAuthorizeCallbackData' #92