### PR TITLE
onApprove should be optional

### DIFF
--- a/projects/ngx-paypal-lib/src/lib/models/paypal-models.ts
+++ b/projects/ngx-paypal-lib/src/lib/models/paypal-models.ts
@@ -35,7 +35,7 @@ export interface IPayPalConfig {
     /**
      * Called when 'onApprove' event occurs
      */
-    onApprove: (data: IOnApproveCallbackData, actions: any) => void;
+    onApprove?: (data: IOnApproveCallbackData, actions: any) => void;
 
     /**
     * Called when authorization on client succeeds


### PR DESCRIPTION
The `onApprove` method in `IPayPalConfig` should be optional.

In the case it should not be and I misunderstood something, the [Authorizing on server](https://github.com/Enngage/ngx-paypal#authorizing-on-server) example should be corrected.