### PR TITLE
Feature/create subscription callback

### DIFF
--- a/projects/ngx-paypal-lib/src/lib/components/paypal.component.ts
+++ b/projects/ngx-paypal-lib/src/lib/components/paypal.component.ts
@@ -211,9 +211,9 @@ export class NgxPaypalComponent implements OnChanges, OnDestroy, AfterViewInit {
                 });
             };
             const createSubscription = (data: ICreateSubscriptionCallbackData, actions: ICreateSubscriptionCallbackActions) => {
-                this.ngZone.run(() => {
+                return this.ngZone.run(() => {
                     if (config.createSubscription) {
-                        config.createSubscription(data, actions);
+                        return config.createSubscription(data, actions);
                     }
                 });
             };

--- a/projects/ngx-paypal-lib/src/lib/components/paypal.component.ts
+++ b/projects/ngx-paypal-lib/src/lib/components/paypal.component.ts
@@ -217,6 +217,13 @@ export class NgxPaypalComponent implements OnChanges, OnDestroy, AfterViewInit {
                     }
                 });
             };
+            const onShippingChange = (data: IOnShippingChangeData, actions: IOnShippingChangeActions) => {
+                return this.ngZone.run(() => {
+                    if (config.onShippingChange) {
+                        return config.onShippingChange(data, actions);
+                    }
+                });
+            };
             const buttonsConfig = {
                 style: config.style,
                 onApprove: (data: IOnApproveCallbackData, actions: IOnApproveCallbackActions) => {
@@ -256,13 +263,6 @@ export class NgxPaypalComponent implements OnChanges, OnDestroy, AfterViewInit {
                         }
                     });
                 },
-                onShippingChange: (data: IOnShippingChangeData, actions: IOnShippingChangeActions) => {
-                    return this.ngZone.run(() => {
-                        if (config.onShippingChange) {
-                            return config.onShippingChange(data, actions);
-                        }
-                    });
-                },
                 onClick: (data: any, actions: IOnClickCallbackActions) => {
                     this.ngZone.run(() => {
                         if (config.onClick) {
@@ -280,7 +280,10 @@ export class NgxPaypalComponent implements OnChanges, OnDestroy, AfterViewInit {
                 // Add the functions if they've been created in the config object
                 // The API only allows one of the two to be set
                 ...((config.createOrderOnClient || config.createOrderOnServer) && { createOrder }),
-                ...(config.createSubscription && { createSubscription })
+                ...(config.createSubscription && { createSubscription }),
+                // The onShippingChange callback cannot be used with subscriptions
+                // so we only add it if it is set
+                ...(config.onShippingChange && { onShippingChange })
             };
             paypal.Buttons(buttonsConfig).render(`#${this.payPalButtonContainerId}`);
         });

--- a/projects/ngx-paypal-lib/src/lib/components/paypal.component.ts
+++ b/projects/ngx-paypal-lib/src/lib/components/paypal.component.ts
@@ -170,6 +170,7 @@ export class NgxPaypalComponent implements OnChanges, OnDestroy, AfterViewInit {
             clientId: config.clientId,
             commit: config.advanced && config.advanced.commit ? config.advanced.commit : undefined,
             currency: config.currency,
+            vault: config.vault,
             extraParams: config.advanced && config.advanced.extraQueryParams ? config.advanced.extraQueryParams : []
         }, (paypal) => {
             this.scriptLoaded.next(paypal);

--- a/projects/ngx-paypal-lib/src/lib/models/paypal-models.ts
+++ b/projects/ngx-paypal-lib/src/lib/models/paypal-models.ts
@@ -1,6 +1,5 @@
 
 export interface IPayPalConfig {
-
     /**
      * Currency - Defaults to USD if not provided
      */
@@ -76,8 +75,15 @@ export interface IPayPalConfig {
     /**
      * Create subscription handler
      * https://developer.paypal.com/docs/subscriptions/integrate/
+     *
+     * Note: the vault property in the advanced configuration also has to be set to true
      */
     createSubscription?: (data: ICreateSubscriptionCallbackData, actions: ICreateSubscriptionCallbackActions) => void;
+
+    /**
+     * Vault - must be set to true when creating subscriptions
+     */
+    vault?: TrueFalse;
 }
 
 export type TrueFalse = 'true' | 'false';
@@ -86,6 +92,7 @@ export interface IPayPalUrlConfig {
     clientId: string;
     currency?: string;
     commit?: TrueFalse;
+    vault?: TrueFalse;
     extraParams?: IQueryParam[];
 }
 

--- a/projects/ngx-paypal-lib/src/lib/services/paypal-script.service.ts
+++ b/projects/ngx-paypal-lib/src/lib/services/paypal-script.service.ts
@@ -44,6 +44,13 @@ export class PayPalScriptService {
             });
         }
 
+        if (config.vault) {
+            params.push({
+                name: 'vault',
+                value: config.vault
+            });
+        }
+
         if (config.extraParams) {
             params.push(...config.extraParams);
         }


### PR DESCRIPTION
- Fixing a major bug in that only one of createSubscription and createOrder can be passed through to the button config
- Adding proper support for the vault parameter
- Making the onShippingChange callback optional (as it's unsupported in the sandbox for subscriptions)