### PR TITLE
Add support for style.height property

### DIFF
--- a/projects/ngx-paypal-lib/src/lib/models/paypal-models.ts
+++ b/projects/ngx-paypal-lib/src/lib/models/paypal-models.ts
@@ -201,6 +201,7 @@ export interface IPayPalButtonStyle {
     color?: 'gold' | 'blue' | 'silver';
     layout?: 'horizontal' | 'vertical';
     tagline?: boolean;
+    height?: number;
 }
 
 export interface ICreateOrderRequest {


### PR DESCRIPTION
Style configuration supports height styling with values between 25 and 55, this only adds the option in the model, sdk validates the value internally

https://developer.paypal.com/docs/checkout/integration-features/customize-button/#size