### PR TITLE
Add missing option for "Buy Now" label

### DIFF
--- a/projects/ngx-paypal-lib/src/lib/models/paypal-models.ts
+++ b/projects/ngx-paypal-lib/src/lib/models/paypal-models.ts
@@ -195,7 +195,7 @@ export interface IOnClickCallbackActions {
 }
 
 export interface IPayPalButtonStyle {
-    label?: 'paypal' | 'checkout' | 'pay' | 'installment';
+    label?: 'paypal' | 'checkout' | 'pay' | 'installment' | 'buynow';
     size?: 'small' | 'medium' | 'large' | 'responsive';
     shape?: 'pill' | 'rect';
     color?: 'gold' | 'blue' | 'silver';


### PR DESCRIPTION
Buy now label is missing in the button options

https://developer.paypal.com/docs/checkout/integration-features/customize-button/#label