### PR TITLE
Phone number is not present inside the ICreateOrderRequest #132

### DIFF
--- a/projects/ngx-paypal-lib/src/lib/models/paypal-models.ts
+++ b/projects/ngx-paypal-lib/src/lib/models/paypal-models.ts
@@ -225,6 +225,7 @@ export interface IPayer {
     birth_date?: string;
     tax_info?: ITaxInfo;
     address?: IAddressPortable;
+    phone?: IPhone;
 }
 
 export interface IApplicationContext {


### PR DESCRIPTION
Issue Fixed. 
Phone interface is added to the Payer Details interface.
This could allow us to prepopulate all the details required for Credit/debit card details